### PR TITLE
Added Commit Count Visualisation and exclude pairs config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 * Provide a regexp of your git commit messages in a file named config.yml
 * There is a default regexp in case you do not provide any config file.
   Default regexp matches messages in this format- |story#|Pair1/Pair2| message
+* You can also specify individual names which you want to filter out from your pairing matrix
+  (Note: Useful in case when refactor/fix commit in the same regex format)
  
 ```
   cd /to your project folder
@@ -36,6 +38,10 @@
   
   /* There is a default regexp. In case, you don't create config.yml file then
      |pair1/pair2| format will be used to match the commit pairs. */
+     
+  // To exclude pair specify name in array inside the config.yml file.
+  //For example,
+  excludedPairs: ['Refactor', 'Fix']
 ```
 
 ### Now goto your git project folder and run,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/abhikur/pairingMatrix#readme",
   "devDependencies": {
-    "mocha": "^3.4.2"
+    "mocha": "^3.4.2",
+    "sinon": "^3.2.1"
   },
   "dependencies": {
     "body-parser": "^1.17.2",

--- a/server/public/index.js
+++ b/server/public/index.js
@@ -4,6 +4,7 @@ var margin = 100;
 var degreeFactor = 180 / Math.PI;
 var circumferenceRadius = 300;
 var colors = d3.scaleOrdinal(d3.schemeCategory20);
+const INDIVIDUAL_NAME_PREFIX = 'name_'
 
 var individualCommitScale = d3.scaleLinear()
   .domain([0, 30])
@@ -68,6 +69,7 @@ function showPairingMatrix(individuals, pairData, committers) {
   matrixGroup.selectAll("text")
     .data(committers).enter()
     .append("text")
+    .attr('id', function(d){return INDIVIDUAL_NAME_PREFIX+d})
     .attr("x", function (d, i) {
       return getCoordinate(d, committers).x - 29 + 'px'
     })
@@ -78,7 +80,6 @@ function showPairingMatrix(individuals, pairData, committers) {
       return d
     })
     .attr("fill", "black")
-
 }
 
 function getAllPairsContaining(name, pairDataArray) {
@@ -98,23 +99,62 @@ function toggleClass(newClass, pair) {
 }
 
 function mouseOut(id, individuals, pairData) {
-  var pairedPeople = getAllPairsContaining(id, pairData);
-  pairedPeople.forEach(function (pairedPerson) {
-    toggleClass("individual", pairedPerson.pair);
-    var pairId = pairedPerson.pair.join('_');
-    d3.selectAll($("#" + pairId))
-      .attr("class", "connection")
-  })
-}
+    var pairedPeople = getAllPairsContaining(id, pairData);
+    pairedPeople.forEach(function(pairedPerson) {
+        toggleClass("individual", pairedPerson.pair);
+        removeCommitCountWithPair(pairedPerson, id);
+        var pairId = pairedPerson.pair.join('_');
+        d3.selectAll($("#" + pairId))
+        .attr("class", "connection")
+    });
+    removeIndividualCommitCount(id, individuals);
+};
 
 function mouseOver(id, individuals, pairData) {
-  var pairedPeople = getAllPairsContaining(id, pairData);
-  pairedPeople.forEach(function (pairedPerson) {
-    toggleClass("individualLarge", pairedPerson.pair)
-    var pairId = pairedPerson.pair.join('_');
-    d3.selectAll($("#" + pairId))
-      .attr("class", "connectionLarge")
-  })
+    var pairedPeople = getAllPairsContaining(id, pairData);
+    pairedPeople.forEach(function(pairedPerson) {
+        toggleClass("individualLarge", pairedPerson.pair)
+        showCommitCountWithPair(pairedPerson, id, individuals);
+        var pairId = pairedPerson.pair.join('_');
+        d3.selectAll($("#" + pairId))
+        .attr("class", "connectionLarge")
+    });
+    showIndividualCommitCount(id, individuals);
+};
+
+function showIndividualCommitCount(id, individuals) {
+	d3.selectAll($("#"+ INDIVIDUAL_NAME_PREFIX + id)).text(id +": " + 0);
+	individuals.forEach(function(individual){
+		if(individual.pair[0].toLowerCase() == id) {
+			d3.selectAll($("#" + INDIVIDUAL_NAME_PREFIX + id)).text(id +": " + individual.commits);
+		}
+	});
+};
+
+function removeIndividualCommitCount(id, individuals) {
+	d3.selectAll($("#"+ INDIVIDUAL_NAME_PREFIX + id)).text(id);
+};
+
+function removeCommitCountWithPair(pairedPerson, id, individuals) {
+	var pair = pairedPerson.pair;
+	var otherPerson;
+	if(pair[0].toLowerCase() == id) {
+		otherPerson = pair[1].toLowerCase();
+	} else {
+		otherPerson = pair[0].toLowerCase();
+	};
+	d3.selectAll($("#" + INDIVIDUAL_NAME_PREFIX + otherPerson)).text(otherPerson)
+}
+
+function showCommitCountWithPair(pairedPerson, id, individuals) {
+	var pair = pairedPerson.pair;
+	var otherPerson;
+	if(pair[0].toLowerCase() == id) {
+		otherPerson = pair[1].toLowerCase();
+	} else {
+		otherPerson = pair[0].toLowerCase();
+	};
+	d3.selectAll($("#" + INDIVIDUAL_NAME_PREFIX + otherPerson)).text(otherPerson + ": " + pairedPerson.commits)
 }
 
 function getNumberOfCommitsOf(person, individuals) {

--- a/server/router.js
+++ b/server/router.js
@@ -10,20 +10,22 @@ module.exports = (app) => {
   app.use(express.static(__dirname + '/public'));
   app.use(express.static(__dirname + '/lib'));
 
-  app.post('/commits', function (req, res) {
-    let config = {
-      regexp: /\|([\w]*)(?:\/)?([\w]*)\|/gi
-    };
-    try {
-      config = yml.safeLoad(fs.readFileSync('config.yml', 'utf8'))
-    } catch (err) {
-      console.log(err.message);
-      console.log("Using default regexp - |story#|Pair1/Pair2| message");
-    }
-    const weeks = req.body.weeks;
-    const commitFetcher = new CommitFetcher(weeks);
-    const commitProvider = new CommitProvider(commitFetcher, config.regexp);
-    const commitData = commitProvider.provideData();
-    res.send(commitData);
-  });
+	app.post('/commits', function(req, res) {
+		let config = {
+			regexp: /\|([\w]*)(?:\/)?([\w]*)\|/gi,
+			excludedPairs: []
+		};
+		try {
+			config = yml.safeLoad(fs.readFileSync('config.yml', 'utf8'))
+		} catch (e) {
+			console.log(e.message)
+			console.log("Using default regexp - |story#|Pair1/Pair2| message");
+		}
+		const weeks = req.body.weeks;
+		const commitFetcher = new CommitFetcher(weeks);
+		const commitProvider = new CommitProvider(commitFetcher, config.regexp, config.excludedPairs);
+		const commitData = commitProvider.provideData();
+		console.log(commitData);
+		res.send(commitData);
+	})
 };

--- a/src/commitDataProvider.js
+++ b/src/commitDataProvider.js
@@ -1,13 +1,14 @@
 const CommitParser = require('./commitParser');
 
 class CommitDataProvider {
-  constructor(commitFetcher, regexp) {
+  constructor(commitFetcher, regexp, excludedPairs) {
     this.commitFetcher = commitFetcher;
     this.regexp = regexp;
+    this.excludedPairs = excludedPairs;
   }
 
   provideData() {
-    const commitParser = new CommitParser(this.regexp);
+    const commitParser = new CommitParser(this.regexp, this.excludedPairs);
     return commitParser.parse(this.commitFetcher.fetch());
   }
 }

--- a/src/commitParser.js
+++ b/src/commitParser.js
@@ -1,8 +1,9 @@
 const _ = require('lodash');
 
 class CommitsParser {
-  constructor(regex) {
+  constructor(regex, excludedPairs=[]) {
     this.regex = regex;
+    this.excludedPairs = excludedPairs;
   }
 
   parse(messages) {
@@ -16,9 +17,11 @@ class CommitsParser {
 
   getPairs(messages) {
     const pairs = messages.map(extractString.bind(null, this.regex)).filter(Boolean);
-    return pairs.map(function (pair) {
-      return pair.split('/');
-    });
+    const excludedPairs = this.excludedPairs;
+    return _.reject(pairs.map(function(unformattedPair) {
+      const pair = unformattedPair.split('/');
+      return _.difference(pair, excludedPairs)
+    }), _.isEmpty);
   }
 }
 

--- a/test/src/commitFetcher.test.js
+++ b/test/src/commitFetcher.test.js
@@ -1,14 +1,23 @@
 const assert = require('assert');
 const CommitsFetcher = require('../../src/commitFetcher');
+const sinon = require('sinon');
+const shell = require('shelljs');
 
 describe('commitsFetcher', () => {
 
   it('should fetch the git commits', () => {
-    const since = '5 weeks ago';
+    const since = '1 weeks ago';
     const commitsFetcher = new CommitsFetcher(since);
+    const mockedShell = sinon.mock(shell)
+    const execCommand = "git log --oneline --since='1 weeks ago'"
+    const execOutput = {stdout: 'Commit1\nCommit2\nCommit3\n'}
+
+    mockedShell.expects('exec').withExactArgs(execCommand, {silent: true}).returns(execOutput);
+
     const commits = commitsFetcher.fetch();
-    assert.ok(commits.length > 1);
-    assert.equal(commits[commits.length - 1], '619e821 Initial commit');
+    
+    mockedShell.verify();
+    assert.deepEqual(commits, ['Commit1', 'Commit2', 'Commit3']);
   });
 
 });

--- a/test/src/commitParser.test.js
+++ b/test/src/commitParser.test.js
@@ -9,13 +9,16 @@ describe('commitsParser', () => {
 
   let messages = [],
     regexp = /\|([\w]*)(?:\/)?([\w]*)\|/gi;
+  const excludePairs = ['Refactor', 'Fix']
 
   before(() => {
     messages = [
       'b3e567y |Abhikur|: first commit',
       '4ega564 |Abhikur/Abhishek|: second message',
       '2e67s88 |Abhi/Abhishek|: third commit',
-      '3b342d4 |Abhi/Abhishek|: fourth commit'
+      '3b342d4 |Abhi/Abhishek|: fourth commit',
+      '3b342d5 |Refactor|: fifth commit',
+      '3b342d6 |Fix|: sixth commit'
     ];
   });
 
@@ -28,11 +31,20 @@ describe('commitsParser', () => {
     assert.equal('Abhi', allPairs[2][0]);
   });
 
+  it('should filter out the pairs by given excludePairs', () => {
+    const commitsParser = new CommitsParser(regexp, excludePairs);
+    const allPairs = commitsParser.getPairs(messages);
+
+    assert.equal('Abhikur', allPairs[0][0]);
+    assert.equal('Abhishek', allPairs[1][1]);
+    assert.equal('Abhi', allPairs[2][0]);
+  });
+
   it('should get individuals with commits', () => {
     const commitsParser = new CommitsParser(regexp);
     const parsedData = commitsParser.parse(messages);
 
-    assert.equal(parsedData.individuals.length, 1);
+    assert.equal(parsedData.individuals.length, 3);
     assert.equal(parsedData.individuals[0].pair.length, 1);
     assert.equal(parsedData.individuals[0].commits, 1);
     assert.equal(parsedData.individuals[0].pair[0], 'Abhikur');
@@ -53,7 +65,7 @@ describe('commitsParser', () => {
   it('should get all committers in the repo', () => {
     const commitsParser = new CommitsParser(regexp);
     const committers = commitsParser.parse(messages).committers;
-    assert.equal(committers.length, 3);
+    assert.equal(committers.length, 5);
     assert.ok(contains('abhikur', committers));
     assert.ok(contains('abhi', committers));
     assert.ok(contains('abhishek', committers));


### PR DESCRIPTION
**Commit Count Visualisation:**
It will show the no of commits of all the members with whom you have paired with. It will also show you the no of commits done individually. The functionality is on hover on each pair in the pairing matrix.

Exclude Pairs Configs:
It will allow the user to exclude all the unnecessary/redundant pairs which are not filtered out in the regex. For eg. - any 'Refactor', 'Fix', 'Log' etc.
